### PR TITLE
"native" method to access Data rather than casting

### DIFF
--- a/ImageSizeFetcher.xcodeproj/project.pbxproj
+++ b/ImageSizeFetcher.xcodeproj/project.pbxproj
@@ -131,7 +131,10 @@
 				52D6D99C1BEFF38C002C0205 /* Configs */,
 				52D6D97D1BEFF229002C0205 /* Products */,
 			);
+			indentWidth = 4;
 			sourceTree = "<group>";
+			tabWidth = 4;
+			usesTabs = 1;
 		};
 		52D6D97D1BEFF229002C0205 /* Products */ = {
 			isa = PBXGroup;

--- a/Sources/ImageSizeFetcher/ImageSizeFetcherParser.swift
+++ b/Sources/ImageSizeFetcher/ImageSizeFetcherParser.swift
@@ -178,8 +178,8 @@ public class ImageSizeFetcherParser {
 				}
 				if data[i+1] >= 0xC0 && data[i+1] <= 0xC3 { // if marker type is SOF0, SOF1, SOF2
 					// "Start of frame" marker which contains the file size
-					let w: UInt16 = data[i + 5, 2]
-					let h: UInt16 = data[i + 7, 2]
+					let h: UInt16 = data[i + 5, 2]
+					let w: UInt16 = data[i + 7, 2]
 
 					let size = CGSize(width: Int(CFSwapInt16(w)), height: Int(CFSwapInt16(h)) );
 					return size

--- a/Tests/ImageSizeFetcherTests/ImageSizeFetcherTests.swift
+++ b/Tests/ImageSizeFetcherTests/ImageSizeFetcherTests.swift
@@ -38,7 +38,7 @@ class ImageSizeFetcherTests: XCTestCase {
 	func generateImagesWithDummyImage(_ count: Int = 5, extension: String, in dest: inout [ImageTestSource]) {
 		for _ in 0..<count {
 			let size = CGSize(width: random(from: 50, to: 500), height: random(from: 50, to: 500))
-			dest.append(ImageTestSource("https://dummyimage.com/\(Int(size.width))x\(Int(size.height)).png", expSize: size))
+			dest.append(ImageTestSource("https://dummyimage.com/\(Int(size.width))x\(Int(size.height)).\(`extension`)", expSize: size))
 		}
 	}
 	


### PR DESCRIPTION
I noticed that the library was casting `Data` to `NSData` to access a subrange but there's support for that without having to bridge.

Random note: When I run the tests, the first couple of randomly generates images fetch fine but the rest fails and the tests do not fail because of that. It looks to me like that `expectation.fulfill()` is called too early